### PR TITLE
improvement: Add support for firmware >=3.0.12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,17 @@
 This is a simple prometheus exporter for the AirGradient air quality monitor. It uses the [AirGradient
 LocalServer API](https://github.com/airgradienthq/arduino/blob/master/docs/local-server.md) to get the data.
 
-**NOTE: Usage of LocalServer API requires the device to be running AirGradient firmware version 3.0.10 or later.**
+## Compatibility
+
+Below is a compatibility matrix for verified versions of the exporter and the AirGradient device firmware.
+
+| AirGradient Firmware | Exporter Version |
+|----------------------|------------------|
+| `x.x.x -> 3.0.9`     | Not Supported    |
+| `3.0.10 -> 3.0.11`   | `>=0.2.0`        |
+| `3.0.12`             | `<=0.3.0`        |
+
+Your mileage may vary with newer versions of the firmware.
 
 ## Usage
 

--- a/internal/collector/airgradient.go
+++ b/internal/collector/airgradient.go
@@ -42,15 +42,45 @@ func NewAirGradient(ctx context.Context, endpoint string) (prometheus.Collector,
 			[]string{"serialno"},
 			nil,
 		),
+		pm01StandardDesc: prometheus.NewDesc(
+			"airgradient_pm01_standard",
+			"PM1 in ug/m3 (standard particle)",
+			[]string{"serialno"},
+			nil,
+		),
+		pm01CountDesc: prometheus.NewDesc(
+			"airgradient_pm01_count",
+			"Particle count 1um per dL",
+			[]string{"serialno"},
+			nil,
+		),
 		pm02Desc: prometheus.NewDesc(
 			"airgradient_pm02",
 			"PM2.5 in ug/m3",
 			[]string{"serialno"},
 			nil,
 		),
+		pm02StandardDesc: prometheus.NewDesc(
+			"airgradient_pm02_standard",
+			"PM2.5 in ug/m3 (standard particle)",
+			[]string{"serialno"},
+			nil,
+		),
+		pm02CountDesc: prometheus.NewDesc(
+			"airgradient_pm02_count",
+			"Particle count 2.5um per dL",
+			[]string{"serialno"},
+			nil,
+		),
 		pm10Desc: prometheus.NewDesc(
 			"airgradient_pm10",
 			"PM10 in ug/m3",
+			[]string{"serialno"},
+			nil,
+		),
+		pm10StandardDesc: prometheus.NewDesc(
+			"airgradient_pm10_standard",
+			"PM10 in ug/m3 (standard particle)",
 			[]string{"serialno"},
 			nil,
 		),
@@ -68,7 +98,25 @@ func NewAirGradient(ctx context.Context, endpoint string) (prometheus.Collector,
 		),
 		pm003CountDesc: prometheus.NewDesc(
 			"airgradient_pm003_count",
-			"Particle count per dL",
+			"Particle count 0.3um per dL",
+			[]string{"serialno"},
+			nil,
+		),
+		pm005CountDesc: prometheus.NewDesc(
+			"airgradient_pm005_count",
+			"Particle count 0.5um per dL",
+			[]string{"serialno"},
+			nil,
+		),
+		pm50CountDesc: prometheus.NewDesc(
+			"airgradient_pm50_count",
+			"Particle count 5um per dL",
+			[]string{"serialno"},
+			nil,
+		),
+		pm10CountDesc: prometheus.NewDesc(
+			"airgradient_pm10_count",
+			"Particle count 10um per dL",
 			[]string{"serialno"},
 			nil,
 		),
@@ -137,11 +185,19 @@ type airgradientCollector struct {
 	deviceInfoDesc      *prometheus.Desc
 	wifiDesc            *prometheus.Desc
 	pm01Desc            *prometheus.Desc
+	pm01StandardDesc    *prometheus.Desc
+	pm01CountDesc       *prometheus.Desc
 	pm02Desc            *prometheus.Desc
+	pm02StandardDesc    *prometheus.Desc
+	pm02CountDesc       *prometheus.Desc
 	pm10Desc            *prometheus.Desc
+	pm10StandardDesc    *prometheus.Desc
 	pm02CompensatedDesc *prometheus.Desc
 	rco2Desc            *prometheus.Desc
 	pm003CountDesc      *prometheus.Desc
+	pm005CountDesc      *prometheus.Desc
+	pm50CountDesc       *prometheus.Desc
+	pm10CountDesc       *prometheus.Desc
 	atmpDesc            *prometheus.Desc
 	atmpCompensatedDesc *prometheus.Desc
 	rhumDesc            *prometheus.Desc
@@ -181,13 +237,21 @@ func (c *airgradientCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	ch <- prometheus.MustNewConstMetric(c.deviceInfoDesc, prometheus.GaugeValue, 1, m.SerialNo, m.Firmware, m.Model, m.LEDMode)
-	ch <- prometheus.MustNewConstMetric(c.wifiDesc, prometheus.GaugeValue, float64(m.Wifi), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.wifiDesc, prometheus.GaugeValue, float64(m.WiFi), m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.pm01Desc, prometheus.GaugeValue, float64(m.PM01), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.pm01StandardDesc, prometheus.GaugeValue, float64(m.PM01Standard), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.pm01CountDesc, prometheus.GaugeValue, float64(m.PM01Count), m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.pm02Desc, prometheus.GaugeValue, float64(m.PM02), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.pm02StandardDesc, prometheus.GaugeValue, float64(m.PM02Standard), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.pm02CountDesc, prometheus.GaugeValue, float64(m.PM02Count), m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.pm10Desc, prometheus.GaugeValue, float64(m.PM10), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.pm10StandardDesc, prometheus.GaugeValue, float64(m.PM10Standard), m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.pm02CompensatedDesc, prometheus.GaugeValue, float64(m.PM02Compensated), m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.rco2Desc, prometheus.GaugeValue, float64(m.RCO2), m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.pm003CountDesc, prometheus.GaugeValue, float64(m.PM003Count), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.pm005CountDesc, prometheus.GaugeValue, float64(m.PM005Count), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.pm50CountDesc, prometheus.GaugeValue, float64(m.PM50Count), m.SerialNo)
+	ch <- prometheus.MustNewConstMetric(c.pm10CountDesc, prometheus.GaugeValue, float64(m.PM10Count), m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.atmpDesc, prometheus.GaugeValue, m.ATMP, m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.atmpCompensatedDesc, prometheus.GaugeValue, m.ATMPCompensated, m.SerialNo)
 	ch <- prometheus.MustNewConstMetric(c.rhumDesc, prometheus.GaugeValue, float64(m.RHUM), m.SerialNo)

--- a/internal/collector/measures.go
+++ b/internal/collector/measures.go
@@ -5,26 +5,33 @@ const (
 )
 
 type measures struct {
-	SerialNo        string  `json:"serialno"`
-	Wifi            int     `json:"wifi"`
-	PM01            int     `json:"pm01"`
-	PM02            int     `json:"pm02"`
-	PM10            int     `json:"pm10"`
-	PM02Compensated int     `json:"pm02Compensated"`
-	RCO2            int     `json:"rco2"`
-	PM003Count      int     `json:"pm003Count"`
+	PM01            float64 `json:"pm01"`
+	PM02            float64 `json:"pm02"`
+	PM10            float64 `json:"pm10"`
+	PM01Standard    float64 `json:"pm01Standard"`
+	PM02Standard    float64 `json:"pm02Standard"`
+	PM10Standard    float64 `json:"pm10Standard"`
+	PM003Count      float64 `json:"pm003Count"`
+	PM005Count      float64 `json:"pm005Count"`
+	PM01Count       float64 `json:"pm01Count"`
+	PM02Count       float64 `json:"pm02Count"`
+	PM50Count       float64 `json:"pm50Count"`
+	PM10Count       float64 `json:"pm10Count"`
 	ATMP            float64 `json:"atmp"`
 	ATMPCompensated float64 `json:"atmpCompensated"`
-	RHUM            int     `json:"rhum"`
-	RHUMCompensated int     `json:"rhumCompensated"`
-	TVOCIndex       int     `json:"tvocIndex"`
-	TVOCRaw         int     `json:"tvocRaw"`
+	RHUM            float64 `json:"rhum"`
+	RHUMCompensated float64 `json:"rhumCompensated"`
+	PM02Compensated float64 `json:"pm02Compensated"`
+	RCO2            float64 `json:"rco2"`
+	TVOCIndex       float64 `json:"tvocIndex"`
+	TVOCRaw         float64 `json:"tvocRaw"`
 	NOXIndex        int     `json:"noxIndex"`
-	NOXRaw          int     `json:"noxRaw"`
+	NOXRaw          float64 `json:"noxRaw"`
 	Boot            int     `json:"boot"`
-	// Deprecated: BootCount is deprecated in favor of Boot
-	BootCount int    `json:"bootCount"`
-	LEDMode   string `json:"ledMode"`
-	Firmware  string `json:"firmware"`
-	Model     string `json:"model"`
+	BootCount       int     `json:"bootCount"`
+	WiFi            int     `json:"wifi"`
+	LEDMode         string  `json:"ledMode"`
+	SerialNo        string  `json:"serialno"`
+	Firmware        string  `json:"firmware"`
+	Model           string  `json:"model"`
 }

--- a/internal/collector/measures.go
+++ b/internal/collector/measures.go
@@ -28,10 +28,11 @@ type measures struct {
 	NOXIndex        int     `json:"noxIndex"`
 	NOXRaw          float64 `json:"noxRaw"`
 	Boot            int     `json:"boot"`
-	BootCount       int     `json:"bootCount"`
-	WiFi            int     `json:"wifi"`
-	LEDMode         string  `json:"ledMode"`
-	SerialNo        string  `json:"serialno"`
-	Firmware        string  `json:"firmware"`
-	Model           string  `json:"model"`
+	// Deprecated: BootCount is deprecated in favor of Boot
+	BootCount int    `json:"bootCount"`
+	WiFi      int    `json:"wifi"`
+	LEDMode   string `json:"ledMode"`
+	SerialNo  string `json:"serialno"`
+	Firmware  string `json:"firmware"`
+	Model     string `json:"model"`
 }


### PR DESCRIPTION
## Summary of Changes

### Field Type Changes
The following fields have been changed from `int` to `float64` for improved precision:
- `PM01`
- `PM02`
- `PM10`
- `PM02Compensated`
- `RCO2`
- `PM003Count`
- `Rhum`
- `RhumCompensated`
- `TVOCIndex`
- `TVOCRaw`
- `NOXRaw`

### New Fields Added
The following fields have been introduced for enhanced measurement granularity:
- `PM01Standard`
- `PM02Standard`
- `PM10Standard`
- `PM005Count`
- `PM01Count`
- `PM02Count`
- `PM50Count`
- `PM10Count`
